### PR TITLE
Ping periodicity changed in config to avoid unwanted results

### DIFF
--- a/mnt/config.json
+++ b/mnt/config.json
@@ -4,7 +4,7 @@
             "name": "google_ping_service",
             "pingConfigs": [
                 {
-                    "periodicity": 1,
+                    "periodicity": 5,
                     "target": "google.com:443"
                 }
             ]
@@ -13,11 +13,11 @@
             "name": "youtube_ping_service",
             "pingConfigs": [
                 {
-                    "periodicity": 1,
+                    "periodicity": 10,
                     "target": "youtube.com:443"
                 },
                 {
-                    "periodicity": 1,
+                    "periodicity": 5,
                     "target": "google.com:443"
                 }
             ]


### PR DESCRIPTION
1s was set to dummy-test concurrent map writes, now set back to 5-10-5 sec for demonstration purposes.